### PR TITLE
make sure the destination directory exists before inflating the template

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,11 +33,12 @@ if (!fs.existsSync(templatePath)) {
 }
 
 const name = path.basename(dest)
-const rest = utils.tuplesToObject(args.map(arg => arg.split('=')))
-
 // todo - use a more robust argument parsing library for this part
+const rest = utils.tuplesToObject(args.map(arg => arg.split('=')))
 const templateArgs = {name, ...rest}
-console.debug(`templateArgs: '${JSON.stringify(templateArgs)}'`)
+
+// make sure the destination directory exists!
+fs.mkdirSync(path.dirname(dest), {recursive: true})
 
 utils.renderTemplate(
   templatePath,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qrohlf/bones",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A simple Javascript scaffolding tool",
   "repository": "github:qrohlf/bones",
   "main": "lib/index.js",


### PR DESCRIPTION
Resolves issues with running bones with nested directory destinations